### PR TITLE
fixes for openel-arduino/index.md

### DIFF
--- a/openel-arduino/index.md
+++ b/openel-arduino/index.md
@@ -12,14 +12,14 @@ As of November 13, 2021, version 3.2.1 is available.
 ## 2. Install Arduino IDE
 
 1. See "Install the Arduino Desktop IDE" in the document, "[Getting Started with Arduino products](https://www.arduino.cc/en/Guide)".
-2. See "Using the Library Manager" in the document, "[Installing Additional Arduino Libraries](https://www.arduino.cc/en/guide/libraries)" and Install [Blynk](https://blynk.io/) library.
+2. See "Using the Library Manager" in the document, "[Installing Additional Arduino Libraries](https://www.arduino.cc/en/Guide/Libraries)" and Install [Blynk](https://blynk.io/) library.
 3. See the document, "[Arduino IDE Development](https://docs.m5stack.com/en/arduino/arduino_development)" and install USB driver, M5Stack boards and M5Stack library.
 
 ## 3. Install OpenEL for Arduino
 
 1. Download the .zip file( [openel-arduino-3.2.1.zip](https://github.com/openel/openel-arduino/releases/tag/v3.2.1) ) from the GitHub repository "[openel/openel-arduino](https://github.com/openel/openel-arduino)".
 2. Open Arduino IDE.
-3. See "Importing a .zip Library" in the document, "[Installing Additional Arduino Libraries](https://www.arduino.cc/en/guide/libraries)" and install OpenEL for Arduino.
+3. See "Importing a .zip Library" in the document, "[Installing Additional Arduino Libraries](https://www.arduino.cc/en/Guide/Libraries)" and install OpenEL for Arduino.
 
 ## 4. How to use OpenEL for Arduino
 

--- a/openel-arduino/index.md
+++ b/openel-arduino/index.md
@@ -26,6 +26,8 @@ As of November 13, 2021, version 3.2.1 is available.
 1. In Arduino IDE, navigate to File > Examples > OpenEL > BALA2
 2. Connect your M5Stack BALA2.
 3. Verify/Compile and Upload BALA2 sketch to your M5Stack BALA2.
+  - You may also need `python` (version 3) and `python-serial` module if they are not already installed to your system.
+    - For Ubuntu 20.04, run the next command to install them: `sudo apt install python-is-python3 python3-serial`
 4. You can see the Self-balancing Robot running slowly.
 
 ### 4.1 How to connect to BALA2 by using Blynk

--- a/openel-arduino/index.md
+++ b/openel-arduino/index.md
@@ -38,9 +38,9 @@ As of November 13, 2021, version 3.2.1 is available.
 47 : #define AUTH "My Blynk Auth Token" // Your Blynk Auth Token
 ```
 3. Verify/Compile and Upload BALA2 sketch to your M5Stack BALA2.
-4. See the document, "[Build your first IoT app in five minutes](https://blynk.io/en/getting-started)" and download and install [Blynk(legacy)](https://play.google.com/store/apps/details?id=cc.blynk) application to youe Android or iPhone..
+4. See the document, "[Build your first IoT app in five minutes](https://blynk.io/en/getting-started)" and download and install [Blynk(legacy)](https://play.google.com/store/apps/details?id=cc.blynk) application to your Android or iPhone.
 
-5. Set up Joystick Settinngs in your Blynk(legacy) application.
+5. Set up Joystick Settings in your Blynk(legacy) application.
 ```
 OUTPUT
 mode:MERGE
@@ -72,7 +72,7 @@ openEL_SensorM5StackGrayMPU6886.hpp
 ```
 
 5. Edit your HAL Component file.
-6. Add your header file and Hal Registration Table into openEL_registoryConfig.cpp file.
+6. Add your header file and Hal Registration Table into openEL_registryConfig.cpp file.
 7. You can use your new device from your sketch by using deviceKindId, vendorId, productId, and instanceId.
 
 ```
@@ -111,7 +111,7 @@ ex.
 
 ## 6. How to Add your HAL Component file to repository
 1. Fork openel-arduino repository.
-2. Add and Commit your HAL Compornent file to your repository.
+2. Add and Commit your HAL Component file to your repository.
 3. Create a pull request.
 
 We look forward to your pull request.


### PR DESCRIPTION
Dear project members,

I followed the `Getting Started with OpenEL for Arduino` [1] guide
on an M5Stack Gray and noticed some minor issues.

The first patch fixes two broken links.
The second patch clarifies that this project depends on `python` and `python-serial` packages.
The third patch fixes some typos.
For more details, please also have a look at comments on each commit.


Sincerely,

Tsuchiya Yuto



References:
[1] https://openel.github.io/openel-arduino/